### PR TITLE
Handle annotation merges

### DIFF
--- a/sigmf/utils.py
+++ b/sigmf/utils.py
@@ -60,9 +60,6 @@ def insert_sorted_dict_list(dict_list, new_entry, key):
     for index, entry in enumerate(dict_list):
         if not entry:
             continue
-        if entry[key] == new_entry[key]:
-            dict_list[index] = dict_merge(entry, new_entry)
-            return dict_list
         if entry[key] > new_entry[key]:
             dict_list.insert(index, new_entry)
             return dict_list

--- a/sigmf/validate.py
+++ b/sigmf/validate.py
@@ -129,7 +129,7 @@ def validate_section_dict_list(data_section, ref_section, section):
             if not bool(result):
                 return result
         this_index = chunk.get(sort_key, 0)
-        if this_index <= last_index:
+        if this_index < last_index:
             return ValidationResult(
                 False,
                 "In Section `{sec}', chunk starting at index {idx} "\

--- a/tests/test_sigmffile.py
+++ b/tests/test_sigmffile.py
@@ -68,6 +68,16 @@ def test_add_annotation():
     f.add_annotation(start_index=0, length=128, metadata=m)
 
 
+def test_add_annotation_with_duplicate_key():
+    f = SigMFFile()
+    f.add_capture(start_index=0)
+    m1 = {"latitude": 40.0, "longitude": -105.0}
+    f.add_annotation(start_index=0, length=128, metadata=m1)
+    m2 = {"latitude": 50.0, "longitude": -115.0}
+    f.add_annotation(start_index=0, length=128, metadata=m2)
+    assert len(f.get_annotations(64)) == 2
+
+
 def test_fromarchive(test_sigmffile):
     tf = tempfile.mkstemp()[1]
     td = tempfile.mkdtemp()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -52,6 +52,12 @@ MD_VALID = """
             "core:sample_count": 120000,
             "core:comment": "Some textual comment about stuff happenning",
             "gsm:xxx": 111
+        },
+        {
+            "core:sample_start": 100000,
+            "core:sample_count": 180000,
+            "core:comment": "Additional annotation at the same start",
+            "gsm:xxx": 111
         }
     ]
 }
@@ -104,7 +110,8 @@ MD_INVALID_SEQUENCE_ANN = """
 
 
 def test_valid_data():
-    assert SigMFFile(MD_VALID).validate()
+    validation_result = SigMFFile(MD_VALID).validate()
+    assert validation_result, str(validation_result)
 
 
 def test_invalid_capture_seq():

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -63,10 +63,57 @@ MD_VALID = """
 }
 """
 
-MD_INVALID_SEQUENCE_CAP = """
+MD_MISSING_COREVERSION_GLOBAL = """
 {
     "global": {
         "core:datatype": "cf32"
+    },
+    "captures": [
+        {
+            "core:sample_start": 9
+        },
+        {
+            "core:sample_start": 10
+        }
+    ],
+    "annotations": [
+        {
+            "core:sample_start": 100000,
+            "core:comment": "stuff"
+        }
+    ]
+}
+"""
+
+MD_MISSING_SAMPLECOUNT_ANN = """
+{
+    "global": {
+        "core:datatype": "cf32",
+        "core:version": "0.0.2"
+    },
+    "captures": [
+        {
+            "core:sample_start": 0
+        }
+    ],
+    "annotations": [
+        {
+            "core:sample_start": 1,
+            "core:comment": "stuff"
+        },
+        {
+            "core:sample_start": 2,
+            "core:comment": "stuff"
+        }
+    ]
+}
+"""
+
+MD_INVALID_SEQUENCE_CAP = """
+{
+    "global": {
+        "core:datatype": "cf32",
+        "core:version": "0.0.2"
     },
     "captures": [
         {
@@ -88,7 +135,8 @@ MD_INVALID_SEQUENCE_CAP = """
 MD_INVALID_SEQUENCE_ANN = """
 {
     "global": {
-        "core:datatype": "cf32"
+        "core:datatype": "cf32",
+        "core:version": "0.0.2"
     },
     "captures": [
         {
@@ -98,10 +146,12 @@ MD_INVALID_SEQUENCE_ANN = """
     "annotations": [
         {
             "core:sample_start": 2,
+            "core:sample_count": 1,
             "core:comment": "stuff"
         },
         {
             "core:sample_start": 1,
+            "core:sample_count": 1,
             "core:comment": "stuff"
         }
     ]
@@ -112,6 +162,11 @@ MD_INVALID_SEQUENCE_ANN = """
 def test_valid_data():
     validation_result = SigMFFile(MD_VALID).validate()
     assert validation_result, str(validation_result)
+
+
+def test_missing():
+    assert not SigMFFile(MD_MISSING_COREVERSION_GLOBAL).validate()
+    assert not SigMFFile(MD_MISSING_SAMPLECOUNT_ANN).validate()
 
 
 def test_invalid_capture_seq():


### PR DESCRIPTION
SigMF used the sample start index as a sorting key for the annotation list, but if two annotations had the same key, they were merged. The annotations are now appended, even in the case of duplicate sorting keys, and sorted according to the key.